### PR TITLE
Treat method modifiers as required in Role::Tiny

### DIFF
--- a/lib/Role/Inspector.pm
+++ b/lib/Role/Inspector.pm
@@ -185,13 +185,23 @@ learn {
 	
 	@methods = $type->methods_provided_by($role)
 		if $type ne 'Role::Tiny';
+
+	my @requires = @{ $Role::Tiny::INFO{$role}{requires} or [] };
+
+	my $modifiers = $Role::Tiny::INFO{$role}{modifiers} || [];
+	foreach my $modifier (@$modifiers) {
+		my @modified = @$modifier[ 1 .. $#$modifier - 1 ];
+		# handle: before ['foo', 'bar'] => sub { ... }
+		@modified = @{ $modified[0] } if ref $modified[0] eq 'ARRAY';
+		push @requires, @modified;
+	}
 	
 	return {
 		name     => $role,
 		type     => $type,
 		api      => [ sort(@methods) ],  # keep: potentially more accurate
 		provides => [ sort keys %{ $type->_concrete_methods_of($role) } ],
-		requires => [ sort @{ $Role::Tiny::INFO{$role}{requires} or [] } ],
+		requires => [ sort(@requires) ],
 	};
 };
 

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -14,6 +14,7 @@
 	:test-recommendation    [ :on "Role::Tiny 1.000000"^^:CpanId ];
 	:test-recommendation    [ :on "Role::Basic"^^:CpanId ];
 	:test-recommendation    [ :on "mop::role"^^:CpanId ];
+	:test-recommendation    [ :on "Class::Method::Modifiers"^^:CpanId ];
 	:develop-recommendation [ :on "Dist::Inkt 0.001"^^:CpanId ];
 	.
 

--- a/t/05roletiny.t
+++ b/t/05roletiny.t
@@ -49,5 +49,17 @@ is_deeply(
 	'can inspect Role::Tiny roles that consume other roles',
 ) or diag explain(get_role_info('Local::RoleTiny2'));
 
+is_deeply(
+	get_role_info('Local::RoleTiny3'),
+	+{
+		name     => 'Local::RoleTiny3',
+		type     => 'Role::Tiny',
+		api      => [sort qw( meth3 req )],
+		requires => [sort qw( mod req req_list1 req_list2 req_list3 req_array_ref1 req_array_ref2 )],
+		provides => [sort qw( meth3 )],
+	},
+	'can inspect Role::Tiny which uses method modifiers',
+) or diag explain(get_role_info('Local::RoleTiny3'));
+
 done_testing;
 

--- a/t/lib/Local/RoleTiny3.pm
+++ b/t/lib/Local/RoleTiny3.pm
@@ -1,0 +1,15 @@
+package Local::RoleTiny3;
+
+use Role::Tiny;
+
+requires qw( req );
+
+around mod => sub { shift->(@_) };
+
+after qw( req_list1 req_list2 req_list3 ) => sub { 1 };
+
+before [ 'req_array_ref1', 'req_array_ref2' ] => sub { 1 };
+
+sub meth3 { 666 }
+
+1;


### PR DESCRIPTION
Method modifiers like
```
around 'method' => sub {
    my $orig = shift;
    ucfirst $orig->(@_);
};
```
are technically required methods, since composing a role will fail if the modified method doesn't exist in the target class. This patch adds these to *requires* in Role::Tiny scanner.